### PR TITLE
Adding a bilinear interpolator

### DIFF
--- a/hrosailing/core/exceptions.py
+++ b/hrosailing/core/exceptions.py
@@ -5,3 +5,13 @@ class FileReadingException(Exception):
     """Exception raised if non-OS-error occurs,
     when reading a file.
     """
+
+class BilinearInterpolatorOutsideGridException(Exception):
+    """Exception raised if bilinear interpolator
+    tries interpolation outside the grid
+    """
+
+class BilinearInterpolatorNoGridException(Exception):
+    """Exception raised if bilinear interpolator
+    detects that values are not in a grid
+    """

--- a/hrosailing/pipeline/extensions.py
+++ b/hrosailing/pipeline/extensions.py
@@ -13,7 +13,8 @@ import hrosailing.processing as pc
 from hrosailing.core.modelfunctions import ws_s_wa_gauss_and_square
 from hrosailing.core.statistics import ComponentWithStatistics
 from hrosailing.polardiagram._polardiagramtable import _Resolution_helper
-
+from hrosailing.core.exceptions import BilinearInterpolatorOutsideGridException
+from hrosailing.core.exceptions import BilinearInterpolatorNoGridException
 
 class PipelineExtension(ComponentWithStatistics, ABC):
     """Base class for all pipeline extensions."""

--- a/hrosailing/pipeline/extensions.py
+++ b/hrosailing/pipeline/extensions.py
@@ -13,8 +13,6 @@ import hrosailing.processing as pc
 from hrosailing.core.modelfunctions import ws_s_wa_gauss_and_square
 from hrosailing.core.statistics import ComponentWithStatistics
 from hrosailing.polardiagram._polardiagramtable import _Resolution_helper
-from hrosailing.core.exceptions import BilinearInterpolatorOutsideGridException
-from hrosailing.core.exceptions import BilinearInterpolatorNoGridException
 
 class PipelineExtension(ComponentWithStatistics, ABC):
     """Base class for all pipeline extensions."""

--- a/hrosailing/processing/__init__.py
+++ b/hrosailing/processing/__init__.py
@@ -15,6 +15,7 @@ from .filter import BoundFilter, Filter, QuantileFilter
 from .imputator import FillLocalImputator, RemoveOnlyImputator
 from .injector import ZeroInjector
 from .interpolator import (
+    BilinearGridInterpolator,
     ArithmeticMeanInterpolator,
     IDWInterpolator,
     ImprovedIDWInterpolator,

--- a/hrosailing/processing/interpolator.py
+++ b/hrosailing/processing/interpolator.py
@@ -490,3 +490,132 @@ def _determine_slope(pts, grid_pt, dist, wts, nhood, norm, slope):
     return (
         xderiv * (grid_pt[0] - pts[:, 0]) + yderiv * (grid_pt[1] - pts[:, 1])
     ) * (dim_of_dist / (dim_of_dist + dist))
+
+
+class BilinearGridInterpolator(Interpolator):
+    """An interpolator that computes..."""
+
+    def __init__(
+        self,
+    ):
+        super().__init__()
+
+    def __repr__(self):
+        return f"BilinearGridInterpolator()"
+
+    def interpolate(self, w_pts, grid_pt):
+        """Interpolates a given `grid_pt` according to the procedure described
+        above.
+
+        Parameters
+        ----------
+        w_pts : WeightedPoints
+            Considered measured points.
+
+        grid_pt : numpy.ndarray of shape (2,)
+            Point that is to be interpolated.
+
+        Returns
+        -------
+        out : int / float
+            Interpolated value at `grid_pt`.
+
+        See also
+        ----------
+        `Interpolator.interpolate`
+        """
+
+        if w_pts.data.shape[1] == 3:
+
+            ws_points = w_pts.data[:, 0]
+            wa_points = w_pts.data[:, 1]
+
+            ws_in = grid_pt[0]
+            wa_in = grid_pt[1]
+
+            lower_ws = ws_points[ws_points <= ws_in]
+            upper_ws = ws_points[ws_points >= ws_in]
+            lower_wa = wa_points[wa_points <= wa_in]
+            upper_wa = wa_points[wa_points >= wa_in]
+
+            closest_lower_ws = (
+                lower_ws[np.argmax(lower_ws)] if len(lower_ws) > 0 else None
+            )
+            closest_upper_ws = (
+                upper_ws[np.argmin(upper_ws)] if len(upper_ws) > 0 else None
+            )
+            closest_lower_wa = (
+                lower_wa[np.argmax(lower_wa)] if len(lower_wa) > 0 else None
+            )
+            closest_upper_wa = (
+                upper_wa[np.argmin(upper_wa)] if len(upper_wa) > 0 else None
+            )
+
+            if (
+                closest_lower_ws == None
+                or closest_upper_ws == None
+                or closest_lower_wa == None
+                or closest_upper_wa == None
+            ):
+                # print(f"DBG: boundaries == 0.0 is not implemented for ws: {ws_in}, wa: {wa_in}")
+                return 0.0
+
+            bs_lws_lwa = self._bs_in_grid(
+                w_pts.data, closest_lower_ws, closest_lower_wa
+            )
+            bs_lws_uwa = self._bs_in_grid(
+                w_pts.data, closest_lower_ws, closest_upper_wa
+            )
+            bs_uws_lwa = self._bs_in_grid(
+                w_pts.data, closest_upper_ws, closest_lower_wa
+            )
+            bs_uws_uwa = self._bs_in_grid(
+                w_pts.data, closest_upper_ws, closest_upper_wa
+            )
+
+            # TODO: check if w_pts.data is really a filled grid (i.e. table), because this interpolator will only work there
+
+            diff_ws = closest_upper_ws - closest_lower_ws
+            diff_wa = closest_upper_wa - closest_lower_wa
+
+            if diff_ws == 0 and diff_wa == 0:
+                return bs_lws_lwa
+            elif diff_ws == 0:
+                lower_wa_factor = (wa_in - closest_lower_wa) / diff_wa
+                bs_lws = (
+                    1.0 - lower_wa_factor
+                ) * bs_lws_lwa + lower_wa_factor * bs_lws_uwa
+                return bs_lws
+            elif diff_wa == 0:
+                lower_ws_factor = (ws_in - closest_lower_ws) / diff_ws
+                bs_lwa = (
+                    1.0 - lower_ws_factor
+                ) * bs_lws_lwa + lower_ws_factor * bs_uws_lwa
+                return bs_lwa
+            else:
+                lower_ws_factor = (ws_in - closest_lower_ws) / diff_ws
+                lower_wa_factor = (wa_in - closest_lower_wa) / diff_wa
+                # interpolation along wa
+                bs_lws = (
+                    1.0 - lower_wa_factor
+                ) * bs_lws_lwa + lower_wa_factor * bs_lws_uwa
+                bs_uws = (
+                    1.0 - lower_wa_factor
+                ) * bs_uws_lwa + lower_wa_factor * bs_uws_uwa
+                # interpolation along ws
+                bs = (
+                    1.0 - lower_ws_factor
+                ) * bs_lws + lower_ws_factor * bs_uws
+                return bs
+
+        return 0.0
+
+    def _bs_in_grid(self, w_pts_data, ws, wa):
+        ws_points = w_pts_data[:, 0]
+        wa_points = w_pts_data[:, 1]
+        matching_row = w_pts_data[(ws_points == ws) & (wa_points == wa)]
+
+        if len(matching_row) > 0:
+            return matching_row[0, 2]
+        else:
+            raise ValueError(f"ERR: no grid point found with ws={ws}, wa={wa}")

--- a/hrosailing/processing/interpolator.py
+++ b/hrosailing/processing/interpolator.py
@@ -19,10 +19,10 @@ import numpy as np
 
 from hrosailing.core.computing import scaled_euclidean_norm
 
-from .neighbourhood import Neighbourhood
-
 from hrosailing.core.exceptions import BilinearInterpolatorOutsideGridException
 from hrosailing.core.exceptions import BilinearInterpolatorNoGridException
+
+from .neighbourhood import Neighbourhood
 
 class Interpolator(ABC):
     """Base class for all `Interpolator` classes."""

--- a/hrosailing/processing/interpolator.py
+++ b/hrosailing/processing/interpolator.py
@@ -497,13 +497,8 @@ def _determine_slope(pts, grid_pt, dist, wts, nhood, norm, slope):
 class BilinearGridInterpolator(Interpolator):
     """An interpolator that computes..."""
 
-    def __init__(
-        self,
-    ):
-        super().__init__()
-
     def __repr__(self):
-        return f"BilinearGridInterpolator()"
+        return "BilinearGridInterpolator()"
 
     def interpolate(self, w_pts, grid_pt):
         """Interpolates a given `grid_pt` according to the procedure described
@@ -580,33 +575,32 @@ class BilinearGridInterpolator(Interpolator):
 
             if diff_ws == 0 and diff_wa == 0:
                 return bs_lws_lwa
-            elif diff_ws == 0:
+            if diff_ws == 0:
                 lower_wa_factor = (wa_in - closest_lower_wa) / diff_wa
                 bs_lws = (
                     1.0 - lower_wa_factor
                 ) * bs_lws_lwa + lower_wa_factor * bs_lws_uwa
                 return bs_lws
-            elif diff_wa == 0:
+            if diff_wa == 0:
                 lower_ws_factor = (ws_in - closest_lower_ws) / diff_ws
                 bs_lwa = (
                     1.0 - lower_ws_factor
                 ) * bs_lws_lwa + lower_ws_factor * bs_uws_lwa
                 return bs_lwa
-            else:
-                lower_ws_factor = (ws_in - closest_lower_ws) / diff_ws
-                lower_wa_factor = (wa_in - closest_lower_wa) / diff_wa
-                # interpolation along wa
-                bs_lws = (
-                    1.0 - lower_wa_factor
-                ) * bs_lws_lwa + lower_wa_factor * bs_lws_uwa
-                bs_uws = (
-                    1.0 - lower_wa_factor
-                ) * bs_uws_lwa + lower_wa_factor * bs_uws_uwa
-                # interpolation along ws
-                bs = (
-                    1.0 - lower_ws_factor
-                ) * bs_lws + lower_ws_factor * bs_uws
-                return bs
+            lower_ws_factor = (ws_in - closest_lower_ws) / diff_ws
+            lower_wa_factor = (wa_in - closest_lower_wa) / diff_wa
+            # interpolation along wa
+            bs_lws = (
+                1.0 - lower_wa_factor
+            ) * bs_lws_lwa + lower_wa_factor * bs_lws_uwa
+            bs_uws = (
+                1.0 - lower_wa_factor
+            ) * bs_uws_lwa + lower_wa_factor * bs_uws_uwa
+            # interpolation along ws
+            bs = (
+                1.0 - lower_ws_factor
+            ) * bs_lws + lower_ws_factor * bs_uws
+            return bs
 
         raise BilinearInterpolatorNoGridException()
 
@@ -617,5 +611,5 @@ class BilinearGridInterpolator(Interpolator):
 
         if len(matching_row) > 0:
             return matching_row[0, 2]
-        else:
-            raise BilinearInterpolatorNoGridException()
+
+        raise BilinearInterpolatorNoGridException()

--- a/hrosailing/processing/interpolator.py
+++ b/hrosailing/processing/interpolator.py
@@ -495,7 +495,7 @@ def _determine_slope(pts, grid_pt, dist, wts, nhood, norm, slope):
 
 
 class BilinearGridInterpolator(Interpolator):
-    """An interpolator that computes..."""
+    """An interpolator that computes the interpolated value by using subsequent linear interpolations in the different axis."""
 
     def __repr__(self):
         return "BilinearGridInterpolator()"

--- a/tests/test_processing/test_interpolator/test_BilinearGridInterpolator.py
+++ b/tests/test_processing/test_interpolator/test_BilinearGridInterpolator.py
@@ -1,0 +1,160 @@
+# pylint: disable-all
+
+from unittest import TestCase
+
+import numpy as np
+
+import hrosailing.core.data as dt
+import hrosailing.processing.interpolator as itp
+
+from hrosailing.core.exceptions import BilinearInterpolatorOutsideGridException
+from hrosailing.core.exceptions import BilinearInterpolatorNoGridException
+
+class TestBilinearGridInterpolator(TestCase):
+    def setUp(self):
+
+        self.wpts = dt.WeightedPoints(
+            np.array([[1, 1, 1], [-1, 1, 1], [-1, -1, 0.5], [1, -1, 1]]),
+            np.ones(4),
+        )
+
+        self.grid_pt = np.array([0, 0])
+
+    def test_repr(self):
+        result = repr(
+            itp.BilinearGridInterpolator()
+        )
+        expected_result = (
+            f"BilinearGridInterpolator()"
+        )
+
+        self.assertEqual(result, expected_result)
+
+    def test_interpolate_default(self):
+        result = itp.BilinearGridInterpolator().interpolate(
+            self.wpts, self.grid_pt
+        )
+        expected_result = 0.875
+
+        self.assertAlmostEqual(result, expected_result)
+
+    def test_interpolate_edge_grid_pt_in_wpts(self):
+        result = itp.BilinearGridInterpolator().interpolate(
+            dt.WeightedPoints(
+                np.array([[-1, 1, 1], [-1, -1, 0.5], [0, 0, 3]]), np.ones(3)
+            ),
+            self.grid_pt,
+        )
+        expected_result = 3
+
+        self.assertEqual(result, expected_result)
+
+    def test_simple(self):
+
+        wpts = dt.WeightedPoints(
+            np.array([[0, 0, 0], 
+                      [0, 1, 1], 
+                      [1, 0, 2],
+                      [1, 1, 4],
+                      ]),
+            np.ones(3),
+        )
+
+        grid_pt = np.array([0, 0])
+        expected_result = 0.0
+        result = itp.BilinearGridInterpolator().interpolate(
+            wpts, grid_pt
+        )
+        self.assertAlmostEqual(result, expected_result)
+
+        grid_pt = np.array([1, 1])
+        expected_result = 4.0
+        result = itp.BilinearGridInterpolator().interpolate(
+            wpts, grid_pt
+        )
+        self.assertAlmostEqual(result, expected_result)
+
+        grid_pt = np.array([0, 1])
+        expected_result = 1.0
+        result = itp.BilinearGridInterpolator().interpolate(
+            wpts, grid_pt
+        )
+        self.assertAlmostEqual(result, expected_result)
+
+        grid_pt = np.array([1, 0])
+        expected_result = 2.0
+        result = itp.BilinearGridInterpolator().interpolate(
+            wpts, grid_pt
+        )
+        self.assertAlmostEqual(result, expected_result)
+
+        grid_pt = np.array([1, 1])
+        expected_result = 4.0
+        result = itp.BilinearGridInterpolator().interpolate(
+            wpts, grid_pt
+        )
+        self.assertAlmostEqual(result, expected_result)
+
+        grid_pt = np.array([0.0, 0.5])
+        expected_result = 0.5
+        result = itp.BilinearGridInterpolator().interpolate(
+            wpts, grid_pt
+        )
+        self.assertAlmostEqual(result, expected_result)
+
+        grid_pt = np.array([0.5, 0.0])
+        expected_result = 1.0
+        result = itp.BilinearGridInterpolator().interpolate(
+            wpts, grid_pt
+        )
+        self.assertAlmostEqual(result, expected_result)
+
+        grid_pt = np.array([1.0, 0.5])
+        expected_result = 3.0
+        result = itp.BilinearGridInterpolator().interpolate(
+            wpts, grid_pt
+        )
+        self.assertAlmostEqual(result, expected_result)
+
+        grid_pt = np.array([0.5, 1.0])
+        expected_result = 2.5
+        result = itp.BilinearGridInterpolator().interpolate(
+            wpts, grid_pt
+        )
+        self.assertAlmostEqual(result, expected_result)
+
+        grid_pt = np.array([0.75, 1.0])
+        expected_result = 3.25
+        result = itp.BilinearGridInterpolator().interpolate(
+            wpts, grid_pt
+        )
+        self.assertAlmostEqual(result, expected_result)
+
+    def test_grid_Error(self):
+
+        wpts = dt.WeightedPoints(
+            np.array([[0, 0, 0], 
+                      [0, 1, 1], 
+                      [1, 0, 2],
+                      [1, 1, 4],
+                      ]),
+            np.ones(3),
+        )
+
+        grid_pt = np.array([-0.1, 0])
+        with self.assertRaises(BilinearInterpolatorOutsideGridException):
+            itp.BilinearGridInterpolator().interpolate(wpts, grid_pt)
+        
+        grid_pt = np.array([0.0, -0.1])
+        with self.assertRaises(BilinearInterpolatorOutsideGridException):
+            itp.BilinearGridInterpolator().interpolate(wpts, grid_pt)
+
+        grid_pt = np.array([1.1, 0.5])
+        with self.assertRaises(BilinearInterpolatorOutsideGridException):
+            itp.BilinearGridInterpolator().interpolate(wpts, grid_pt)
+
+        grid_pt = np.array([0.1, 2.33])
+        with self.assertRaises(BilinearInterpolatorOutsideGridException):
+            itp.BilinearGridInterpolator().interpolate(wpts, grid_pt)
+
+        print("EOT")

--- a/tests/test_processing/test_interpolator/test_BilinearGridInterpolator.py
+++ b/tests/test_processing/test_interpolator/test_BilinearGridInterpolator.py
@@ -157,4 +157,3 @@ class TestBilinearGridInterpolator(TestCase):
         with self.assertRaises(BilinearInterpolatorOutsideGridException):
             itp.BilinearGridInterpolator().interpolate(wpts, grid_pt)
 
-        print("EOT")


### PR DESCRIPTION
Added implementation of a bilinear interpolator. The interpolator assumes that points are provided in a grid. The interpolator gives nice interpolation results for table-based polar diagrams. See screenshots attached, comparing "bilinear" and "arithmetic mean" interpolators (via "Interpolator" option in sidebar).

The interpolator throws custom exceptions (e.g. `BilinearInterpolatorOutsideGridException`) if no grid points can be found surrounding the requested position.

Added tests for the bilinear interpolator in `tests/test_processing/test_interpolator/test_BilinearGridInterpolator.py`.

<img width="1225" alt="Screenshot 2025-01-06 at 14 07 34" src="https://github.com/user-attachments/assets/02105fa1-e26a-4888-b329-a62b328f4294" />
<img width="1225" alt="Screenshot 2025-01-06 at 14 07 30" src="https://github.com/user-attachments/assets/9dbed43a-b30a-4d8d-a1bc-4aff5d872b56" />
