### PR TITLE
Fix `convex_direction` exact angle matching bug

### DIFF
--- a/hrosailing/cruising/basics.py
+++ b/hrosailing/cruising/basics.py
@@ -129,10 +129,10 @@ def convex_direction(
         edge[0].sail = info[0][i1]
         edge[1].sail = info[0][i2]
 
-    if edge[0] == direction:
+    if edge[0].angle == direction:
         return [edge[0]]
 
-    if edge[1] == direction:
+    if edge[1].angle == direction:
         return [edge[1]]
 
     # direction lies on a common edge of polar diagram and convex hull

--- a/tests/test_cruising/test_basics.py
+++ b/tests/test_cruising/test_basics.py
@@ -31,3 +31,23 @@ class TestHROPolar(unittest.TestCase):
         self.assertAlmostEqual(
             1, direction[0].proportion + direction[1].proportion
         )
+
+    def test_convex_direction_exact_angle_match(self):
+        """Test that convex_direction returns exact angles when target matches a vertex."""
+        # Test with 90° - should return exactly 90°, not a neighboring angle
+        direction = convex_direction(self.pd, 1, 90)
+        
+        self.assertEqual(1, len(direction), "Should return single direction for exact match")
+        self.assertEqual(90, direction[0].angle, "Should return exact target angle 90°")
+        
+        # Test with 180° - should return exactly 180°, not a neighboring angle  
+        direction = convex_direction(self.pd, 1, 180)
+        
+        self.assertEqual(1, len(direction), "Should return single direction for exact match")
+        self.assertEqual(180, direction[0].angle, "Should return exact target angle 180°")
+        
+        # Test with 45° - should return exactly 45°, not a neighboring angle
+        direction = convex_direction(self.pd, 1, 45)
+        
+        self.assertEqual(1, len(direction), "Should return single direction for exact match")
+        self.assertEqual(45, direction[0].angle, "Should return exact target angle 45°")


### PR DESCRIPTION
 ### Problem
  `convex_direction()` returns incorrect angles when the target direction exactly matches a convex hull vertex
  (e.g., returns 89° instead of 90°).

 ### Root Cause
  Lines 132-136 compare `Direction` objects directly with `float` values:
  ```python
  if edge[0] == direction:  # Direction != float (always False)
```

### Solution

  Compare the angle attributes:
```python
  if edge[0].angle == direction:  # float == float (works correctly)
```

### Changes

  - Fix: `hrosailing/cruising/basics.py` - correct angle comparison logic
  - Test: Add `test_convex_direction_exact_angle_match()` covering 45°, 90°, and 180° exact matches

### Testing

  `python -m pytest tests/test_cruising/test_basics.py::TestHROPolar::test_convex_direction_exact_angle_match -v`

  | Status     | Result                               |
  |------------|--------------------------------------|
  | Before fix |  FAIL - returns wrong angles        |
  | After fix  | PASS - returns exact target angles |

### Impact

  - Backwards compatible
  - Improves accuracy for optimal tack/gybe calculations
